### PR TITLE
fix: make Channel.Close safe for concurrent callers

### DIFF
--- a/unlimited_channel.go
+++ b/unlimited_channel.go
@@ -3,6 +3,7 @@ package unlimitedchannel
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 
 	"github.com/pierrre/go-libs/goroutine"
@@ -13,10 +14,11 @@ import (
 //
 // It must be created with [New], and closed with [Channel.Close] to release resources.
 type Channel[T any] struct {
-	in     chan T
-	out    chan T
-	length atomic.Int64
-	wait   func()
+	in        chan T
+	out       chan T
+	length    atomic.Int64
+	closeOnce sync.Once
+	wait      func()
 }
 
 // New creates a new [Channel].
@@ -61,18 +63,21 @@ func (c *Channel[T]) Len() int {
 // Close closes the channel.
 //
 // It releases all resources used by the channel: buffered values are discarded, and the input/output channels are closed.
+// It is safe for concurrent callers: only the first call releases resources, and subsequent calls block until the first returns.
 func (c *Channel[T]) Close() {
-	inOpen := true
-	for inOpen { // Drain the input channel, and ensure it is closed.
-		select {
-		case _, inOpen = <-c.in:
-		default:
-			close(c.in)
+	c.closeOnce.Do(func() {
+		inOpen := true
+		for inOpen { // Drain the input channel, and ensure it is closed.
+			select {
+			case _, inOpen = <-c.in:
+			default:
+				close(c.in)
+			}
 		}
-	}
-	for range c.out { // Drain the output channel until it is closed.
-	}
-	c.wait()
+		for range c.out { // Drain the output channel until it is closed.
+		}
+		c.wait()
+	})
 }
 
 func (c *Channel[T]) run() { //nolint:gocyclo // Yes it's complex.

--- a/unlimited_channel_test.go
+++ b/unlimited_channel_test.go
@@ -3,6 +3,7 @@ package unlimitedchannel
 import (
 	"fmt"
 	"strconv"
+	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -51,6 +52,19 @@ func Test(t *testing.T) {
 	}
 	c.Close()
 	_, ok := <-out
+	assert.False(t, ok)
+}
+
+func TestCloseConcurrent(t *testing.T) {
+	c := newTestChannel(t, WithBuffer(0))
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Go(func() {
+			c.Close()
+		})
+	}
+	wg.Wait()
+	_, ok := <-c.Output()
 	assert.False(t, ok)
 }
 


### PR DESCRIPTION
## Problem

`Channel.Close` was unsafe for concurrent callers. Two goroutines could both reach the `default: close(c.in)` branch before either close landed, causing a double-close panic on `c.in`.

The concurrency contract was also undocumented.

## Fix

Wrap the `Close` body in `sync.Once`:
- Only the first call drains the channels, closes `c.in`, and waits for the goroutine to finish.
- Subsequent calls block until the first returns, then return as no-ops.

Documented the concurrent-safety guarantee in the doc comment.

## Test

Added `TestCloseConcurrent` which calls `Close` from 100 goroutines simultaneously and verifies the output channel is closed. Run with `-race` and passes.