### PR TITLE
docs: clarify WithContext has no cancellation effect on the goroutine

### DIFF
--- a/unlimited_channel.go
+++ b/unlimited_channel.go
@@ -163,9 +163,8 @@ func buildOptions(opts []Option) *options {
 // Option represents an option for [New].
 type Option func(*options)
 
-// WithContext sets the [context.Context] for the channel.
-// It runs the goroutine that handles the channel.
-// Cancelling the context has no effect on the channel.
+// WithContext sets the [context.Context] of the internal goroutine that handles the channel.
+// Cancelling the context does not stop the goroutine: it only exits when [Channel.Close] is called, or when the input channel is closed.
 // It uses [context.Background] by default.
 func WithContext(ctx context.Context) Option {
 	return func(o *options) {

--- a/unlimited_channel_test.go
+++ b/unlimited_channel_test.go
@@ -1,6 +1,7 @@
 package unlimitedchannel
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
@@ -105,6 +106,22 @@ func TestSlowReceiver(t *testing.T) {
 		in <- 1
 		time.Sleep(1 * time.Second)
 		<-out
+	})
+}
+
+func TestWithContextCancel(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		c := newTestChannel(t, WithContext(ctx))
+		in, out := c.Input(), c.Output()
+		in <- 1
+		cancel()
+		time.Sleep(1 * time.Second)
+		v := <-out
+		assert.Equal(t, v, 1)
+		in <- 2
+		v = <-out
+		assert.Equal(t, v, 2)
 	})
 }
 


### PR DESCRIPTION
## Summary

The `WithContext` option accepts a `context.Context`, which implies context-driven shutdown (cancellation/timeout). However, the context has no cancellation effect on the internal goroutine — it only exits via `Channel.Close()` or closing the input channel.

The previous doc comment said "Cancelling the context has no effect on the channel" but didn't explain what **does** cause the goroutine to exit. This PR improves the documentation to be explicit about that, and adds a regression test verifying the channel keeps working after context cancellation.

## Changes

- **`WithContext` doc comment**: rewritten to state that cancelling the context does not stop the goroutine, and that it only exits when `Close` is called or the input channel is closed.
- **`TestWithContextCancel`**: new test using `synctest` that cancels the context mid-operation and verifies values can still be sent and received afterwards.

## Test coverage

```
total: 100.0% of statements
```