### PR TITLE
improve: set newElem.next to nil in enqueue for explicit correctness

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -17,6 +17,7 @@ func (q *queue[T]) enqueue(value T) {
 		newElem = &queueElement[T]{}
 	}
 	newElem.value = value
+	newElem.next = nil
 	if q.head == nil {
 		q.head = newElem
 	}


### PR DESCRIPTION
## Problem

`enqueue` sets `newElem.value` but never `newElem.next` (queue.go:19).
When an element is recycled from the pool, its `next` being `nil` depends entirely on `dequeue` nilling `next` (queue.go:42) before returning it to the pool via `Put`.

Any future change to `dequeue` that drops the `next = nil` would silently corrupt the list: a recycled element would carry a stale `next` pointer, and setting it as the new tail would link the tail to freed/arbitrary elements.

## Fix

Set `newElem.next = nil` explicitly in `enqueue`, so list correctness no longer depends on `dequeue`'s pool-return behavior.

## Refs

- queue.go:14-27 (enqueue)
- queue.go:29-45 (dequeue)

## Tests

- `go test -race -coverprofile=cover.out ./...` — 100.0% coverage
- `make all` — clean